### PR TITLE
Make containers not overflow on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -18,6 +18,7 @@ body {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   max-width: 800px;
   margin: 0 auto;
+  width: 80%;
 }
 
 h1 {
@@ -35,6 +36,8 @@ h2 {
 img {
   display: block;
   margin: 0 auto;
+  height: auto;
+  max-width: 100%;
 }
 
 .stats {


### PR DESCRIPTION
Change container windows to consistently display the same between mobile and PC (also makes containers width consistent this can be changed if you want)
 
![image](https://github.com/user-attachments/assets/c0c56f1d-9f4f-4875-9c08-06838e4acf10)
![image](https://github.com/user-attachments/assets/53fdbd2b-6a11-4ad1-9fa6-28d95bf23b1d)

Tested with Firefox debug for Iphone 11 Pro and Galaxy Note 20, these tools can be a bit inconsistent but should hopefully be accurate. 